### PR TITLE
MYM-71-BE-Refresh-Token-bcrypt-issue

### DIFF
--- a/backend/back/src/auth/auth.service.ts
+++ b/backend/back/src/auth/auth.service.ts
@@ -147,7 +147,8 @@ export class AuthService {
 			twoFactorEnabled: user.twoFactorEnabled,
 			twoFactorAuthenticated: twoFactor,
 		}
-		return await this.jwtService.sign(payload);
+		const access_token = await this.jwtService.sign(payload);
+		return access_token;
 	}
 
 	async genRefreshToken(user: Omit<User, 'password'>, twoFactor: boolean) {
@@ -158,7 +159,7 @@ export class AuthService {
 			twoFactorAuthenticated: twoFactor,
 		}
 		const refreshToken = await this.jwtService.sign(payload, { expiresIn: config.get<string>('jwt-refresh.exp')});
-		return { refreshToken: refreshToken };	
+		return refreshToken;	
 	}
 
 	async verifyJwtToken(refreshToken: string): Promise<TokenPayload> {

--- a/backend/back/src/login/login.controller.ts
+++ b/backend/back/src/login/login.controller.ts
@@ -67,7 +67,7 @@ export class LoginController {
 		const user = await this.authService.intraSignIn(code);
 		const { access_token, refresh_token } = await this.authService.login(user);
 
-		await this.userService.setUserRefreshToken(user, refresh_token.refreshToken);
+		await this.userService.setUserRefreshToken(user, refresh_token.split('.')[1]);
 		res.cookie('accessToken', access_token,
 			{
 				httpOnly: true,
@@ -124,7 +124,7 @@ export class LoginController {
 	})
 	@swagger.ApiBadRequestResponse({ description: 'Refresh Token이 유효하지 않거나 만료되었을 때', type: ResponseErrorDto })
 	@swagger.ApiUnauthorizedResponse({ description: 'Refresh Token이 유효하지만 해당 유저가 없을 때', type: ResponseErrorDto })
-	async refreshAccessTokens(@Headers('authorization') refresh_token: string) {
+	async refreshAccessTokens(@Headers('authorization') refresh_token: string, @Req() request) {
 		const refreshToken = refresh_token.split(' ')[1];
 		return await this.authService.refreshAccessToken(refreshToken);
 	}


### PR DESCRIPTION
설명

- 문제의 발견

    @Post('/oauth/refresh')
	async refreshAccessTokens(@Headers('authorization') refresh_token: string, @Req() request) {
refresh token으로, access token 을 재발급 받는 refreshAccessTokens 함수에서
refresh token이 아닌 access token 을 전달해도, access token 이 재발급 되는 기현상 발생

- 문제의 분석

 refresh token 과 access token  간의 payload 차이가 exp(만료시간) 밖에 없었는데, bcrypt 함수의 암호화 가능한 byte 가 56 byte 였다. 따라서 refresh token 과 access token 을 bcrypt 했을때 저장되는 부분은 둘다 똑같은 {uid} 까지 여서 bcrypt.compare 시 같다고 나오는 문제가 있었다.

- 문제의 해결

DB 에 저장할때 encoding 된 JWT 값 중, . 기준으로 나누어 payload 부분만 bcrypt 로 암호화 하도록 변경

refresh token 에 refresh: true 라는 payload 항목 추가