### PR TITLE
[fix] GamePage Logic

### DIFF
--- a/frontend/front/src/components/ChatPage/UserInfoModal.tsx
+++ b/frontend/front/src/components/ChatPage/UserInfoModal.tsx
@@ -11,6 +11,7 @@ import { refreshTokenAtom } from "../../components/atom/LoginAtom";
 import * as socket from "../../socket/chat.socket";
 import { useNavigate } from "react-router-dom";
 import { UserAtom, isMyProfileAtom, ProfileAtom } from "../../components/atom/UserAtom";
+import { isPrivateAtom } from "../atom/GameAtom";
 
 export default function UserInfoModal() {
   const [userInfoModal, setUserInfoModal] = useAtom(userInfoModalAtom);
@@ -20,6 +21,7 @@ export default function UserInfoModal() {
   const [followingList, setFollowingList] = useAtom(chatAtom.followingListAtom);
   const [focusRoom] = useAtom(chatAtom.focusRoomAtom);
   const [blockList, setBlockList] = useAtom(chatAtom.blockListAtom);
+  const [, setIsPrivate] = useAtom(isPrivateAtom);
 
   const navigate = useNavigate();
   const [, setRefreshToken] = useAtom(refreshTokenAtom);
@@ -69,16 +71,19 @@ export default function UserInfoModal() {
       if (refreshResponse !== 201) {
         logOutHandler();
       } else {
-        const getProfileResponse = await api.GetOtherProfile(adminConsole, setProfile, userInfo.uid);
+        const getProfileResponse = await api.GetOtherProfile(
+          adminConsole,
+          setProfile,
+          userInfo.uid
+        );
         if (getProfileResponse === 401) {
           logOutHandler();
-        }
-        else {
-          navigate('/profile');
+        } else {
+          navigate("/profile");
         }
       }
     } else {
-      navigate('/profile');
+      navigate("/profile");
     }
   }
 
@@ -100,8 +105,11 @@ export default function UserInfoModal() {
 
   const Invite = () => {
     if (isDefaultUser) return;
+    setIsPrivate(true); // private Game - Custom Match
     alert("invite");
     infoModalOff();
+    // TODO: socket - Game invite Logic
+    // navigate("/game");
   };
 
   const Ignore = () => {

--- a/frontend/front/src/components/GamePage/GameInviteModal.tsx
+++ b/frontend/front/src/components/GamePage/GameInviteModal.tsx
@@ -1,6 +1,7 @@
 import { useAtom } from "jotai";
 import "../../styles/GameInviteModal.css";
 import { gameInviteModalAtom } from "../atom/ModalAtom";
+import { isPrivateAtom } from "../atom/GameAtom";
 
 export default function GameInviteModal({
   from,
@@ -12,13 +13,21 @@ export default function GameInviteModal({
   DeclineBtn: () => void;
 }) {
   const [, setGameInviteModal] = useAtom(gameInviteModalAtom);
+  const [, setIsPrivate] = useAtom(isPrivateAtom);
 
   return (
     <>
       <div className="GameInviteModalBG" />
       <div className="GameInviteModal">
         <div className="GameInviteModalTxt">{`Game Invite\nfrom ${from}`}</div>
-        <button className="GameInviteModalAcceptBtn" onClick={AcceptBtn}>
+        <button
+          className="GameInviteModalAcceptBtn"
+          onClick={() => {
+            AcceptBtn();
+            setGameInviteModal(false);
+            setIsPrivate(true);
+          }}
+        >
           Accept
         </button>
         <button
@@ -26,8 +35,7 @@ export default function GameInviteModal({
           onClick={() => {
             DeclineBtn();
             setGameInviteModal(false);
-          }
-          }
+          }}
         >
           Decline
         </button>

--- a/frontend/front/src/components/TopBar.tsx
+++ b/frontend/front/src/components/TopBar.tsx
@@ -9,6 +9,7 @@ import * as socket from "../socket/chat.socket";
 import * as chatAtom from "../components/atom/ChatAtom";
 import { AdminLogPrinter } from "../event/event.util";
 import { isMyProfileAtom } from "../components/atom/UserAtom";
+import { isPrivateAtom } from "./atom/GameAtom";
 
 export default function TopBar() {
   return (
@@ -51,8 +52,14 @@ function ChatBtn() {
 }
 
 function QueueBtn() {
+  const [, setIsPrivate] = useAtom(isPrivateAtom);
+
+  const queueHandler = () => {
+    setIsPrivate(false);
+  };
+
   return (
-    <div className="TopBarBtn">
+    <div className="TopBarBtn" onClick={queueHandler}>
       <NavLink to="/game" className="AStyle" style={getNavLinkStyle}>
         Queue
       </NavLink>
@@ -68,7 +75,7 @@ function ProfileBtn() {
   };
 
   return (
-    <div className="TopBarBtn" onClick={profileHandler} >
+    <div className="TopBarBtn" onClick={profileHandler}>
       <NavLink to="/profile" className="AStyle" style={getNavLinkStyle}>
         Profile
       </NavLink>

--- a/frontend/front/src/components/atom/GameAtom.ts
+++ b/frontend/front/src/components/atom/GameAtom.ts
@@ -1,7 +1,11 @@
 import { atom } from "jotai";
 // import type * as DTO from '../../socket/game.dto';
 
-export const isQueueAtom = atom<boolean>(false);
+export const isLoadingAtom = atom<boolean>(false);
+
+export const isPrivateAtom = atom<boolean>(false);
+
+export const isGameStartedAtom = atom<boolean>(false);
 
 export let lastUpdate = atom<number>(Date.now());
 

--- a/frontend/front/src/pages/GamePage.tsx
+++ b/frontend/front/src/pages/GamePage.tsx
@@ -5,7 +5,7 @@ import PingPong from "../components/GamePage/PingPong";
 import TopBar from "../components/TopBar";
 
 import { useAtom } from "jotai";
-import { isQueueAtom } from "../components/atom/GameAtom";
+import { isGameStartedAtom, isLoadingAtom, isPrivateAtom } from "../components/atom/GameAtom";
 
 import { GameCoordinateAtom } from "../components/atom/GameAtom";
 import * as game from "../socket/game.socket";
@@ -16,13 +16,15 @@ import LadderBoard from "../components/GamePage/LadderBoard";
 import * as chatAtom from "../components/atom/ChatAtom";
 
 import { PressKey, AdminLogPrinter } from "../event/event.util";
+import Waiting from "../components/GamePage/Waiting";
 
 export default function GamePage() {
   const [showComponent, setShowComponent] = useState(true);
-  const [isLoading, setIsLoading] = useState(false);
   const [gameResultModal, setGameResultModal] = useAtom(gameResultModalAtom);
 
-  const [isQueue, setIsQueue] = useAtom(isQueueAtom);
+  const [isLoading, setIsLoading] = useAtom(isLoadingAtom);
+  const [isPrivate, setIsPrivate] = useAtom(isPrivateAtom);
+  const [isGameStart, setIsGameStart] = useAtom(isGameStartedAtom);
 
   const [coordinate, setCoordinate] = useAtom(GameCoordinateAtom);
   const [adminConsole, setAdminConsole] = useAtom(chatAtom.adminConsoleAtom);
@@ -31,10 +33,10 @@ export default function GamePage() {
     setAdminConsole((prev) => !prev);
   });
 
-  if (isQueue === false) {
+  if (isLoading === false) {
     AdminLogPrinter(adminConsole, "gameSocket connect");
     game.gameSocket.connect();
-    setIsQueue(true);
+    setIsLoading(true);
   }
 
   useEffect(() => {
@@ -49,30 +51,40 @@ export default function GamePage() {
 
   return (
     <BackGround>
-      {
-        adminConsole
-          ? <div>
-            <button
-              onClick={() => {
-                const loading = !isLoading;
-                setIsLoading(loading);
-              }}
-            >
-              LadderRanking
-            </button>
-            <button
-              onClick={() => {
-                const gameOverModal = !gameResultModal;
-                setGameResultModal(gameOverModal);
-              }}
-            >
-              GameOver
-            </button>
-          </div>
-          : ''
-      }
+      {adminConsole ? (
+        <div>
+          <button
+            onClick={() => {
+              const loading = !isLoading;
+              setIsLoading(loading);
+            }}
+          >
+            LadderRanking
+          </button>
+          <button
+            onClick={() => {
+              const gameOverModal = !gameResultModal;
+              setGameResultModal(gameOverModal);
+            }}
+          >
+            GameOver
+          </button>
+        </div>
+      ) : (
+        ""
+      )}
       <TopBar />
-      {isLoading ? <LadderBoard /> : <PingPong />}
+      {isLoading ? (
+        isPrivate ? (
+          <Waiting />
+        ) : (
+          <LadderBoard />
+        )
+      ) : isGameStart ? (
+        <PingPong />
+      ) : (
+        <Waiting />
+      )}
       {gameResultModal ? <GameResultModal result={true} leftScore={5} rightScore={4} /> : null}
     </BackGround>
   );


### PR DESCRIPTION
isLoading (isLoadingAtom)
isPrivate (isPrivateAtom)
isGameStart (isGameStartAtom)

on/off 따라 게임화면 달라지도록 수정

소켓 이벤트에 따라 Atom 3개 toggle 해주면 될듯

채팅창에서 invite 누르거나 수락하면 isPrivate 켜지고 TopBar에서 Queue 누르면 isPrivate 꺼지도록 구현

// TODO: ChatPage 에서 Invite 하거나 GameInviteModal 에서 수락누르면 GamePage로 이동하도록 구현