### PR TITLE
edit dm logic, and edit db dm service

### DIFF
--- a/backend/back/src/chat/chat.gateway.ts
+++ b/backend/back/src/chat/chat.gateway.ts
@@ -1074,33 +1074,19 @@ export class EventsGateway
 	async handleDmList(socket: Socket, uid: number) {
 
 		try {
-			const dmListFromMe = await this.databaseService.findDMByUserId(uid);
-			const dmListToMe = await this.databaseService.findDMByUserIdReceive(uid);
+			const allDmList = await this.databaseService.findAllDM(uid);
 			const dmListQueue = new Set<number>();
-			const mergeDmList = dmListFromMe?.concat(dmListToMe!);
-
-			dmListFromMe?.forEach((dm) => {
-				if (dmListQueue.has(dm.receiverId) === false) {
-					dmListQueue.add(dm.receiverId);
-				}
+			allDmList?.forEach((dm) => {
+				dmListQueue.add(dm.senderId);
+				dmListQueue.add(dm.receiverId);
 			});
-
-			dmListToMe?.forEach((dm) => {
-				if (dmListQueue.has(dm.senderId) === false) {
-					dmListQueue.add(dm.senderId);
-				}
-			});
-
-			mergeDmList?.sort((a, b) => {
-				return a.did - b.did;
-			});
+			delete dmListQueue[uid];
 
 			const resDmUserList: Record<number, ClientUserDto> = {};
-
 			for (const uid of dmListQueue) {
 				if (userList[uid] === undefined) {
 					const targetUser = await this.userService.getUserByUid(uid);
-					if (targetUser == undefined) return;
+					if (targetUser === null) continue;
 					resDmUserList[uid] = {
 						userDisplayName: targetUser.nickname,
 						userProfileUrl: targetUser.profileUrl,
@@ -1114,7 +1100,7 @@ export class EventsGateway
 					};
 				}
 			};
-			this.nsp.to(socket.id).emit("dm-list", resDmUserList, mergeDmList);
+			this.nsp.to(socket.id).emit("dm-list", resDmUserList, allDmList);
 		} catch (error) {
 			this.logger.error(`handleDmList - ${error} `);
 		}

--- a/backend/back/src/database/database.service.ts
+++ b/backend/back/src/database/database.service.ts
@@ -65,7 +65,7 @@ export class DatabaseService {
         await this.userRepository.save(user);
     }
 
-    async updateUserElo(uid: number, elo: number):Promise<void> {
+    async updateUserElo(uid: number, elo: number): Promise<void> {
         try {
             await this.userRepository.update({ uid }, { elo });
         } catch (error) {
@@ -73,7 +73,7 @@ export class DatabaseService {
         }
     }
 
-    async updateUserNickname(uid: number, nickname: string):Promise<void> {
+    async updateUserNickname(uid: number, nickname: string): Promise<void> {
         try {
             await this.userRepository.update({ uid }, { nickname });
         } catch (error) {
@@ -190,10 +190,18 @@ export class DatabaseService {
             .createQueryBuilder('dm')
             .where('dm.senderId = :senderId', { senderId })
             .andWhere('dm.receiverId = :receiverId', { receiverId })
-            .getRawMany();
+            .getMany();
     }
 
-    //player 1 uid, player 2 uid, score 1, score 2, gametype 
+    async findAllDM(uid: number): Promise<DirectMessage[] | null> {
+        return await this.directMessageRepository
+            .createQueryBuilder('dm')
+            .where('dm.senderId = :senderId', { senderId: uid })
+            .orWhere('dm.receiverId = :receiverId', { receiverId: uid })
+            .getMany();
+    }
+
+    //player 1 uid, player 2 uid, score 1, score 2, gametype
     // async saveGame(gameResult : Game){
     //     return await this.gameRepository.save(gameResult);
     // }
@@ -207,8 +215,8 @@ export class DatabaseService {
         try {
             await queryRunner.manager.save(Game, result);
             if (gameType === GameType.PUBLIC) {
-                await queryRunner.manager.update(User, {uid: result.winner.uid}, {elo: winnerElo});
-                await queryRunner.manager.update(User, {uid: result.loser.uid}, {elo: loserElo});
+                await queryRunner.manager.update(User, { uid: result.winner.uid }, { elo: winnerElo });
+                await queryRunner.manager.update(User, { uid: result.loser.uid }, { elo: loserElo });
             }
             await queryRunner.commitTransaction();
         } catch (e) {
@@ -218,13 +226,13 @@ export class DatabaseService {
         }
     }
 
-    
+
     //GAME
-    async findAllGameByUserid(uid: number){
-        const winGames  = await this.gameRepository.createQueryBuilder('gm')
-        .where('gm.winner.uid = :uid', {uid}).getRawMany();
+    async findAllGameByUserid(uid: number) {
+        const winGames = await this.gameRepository.createQueryBuilder('gm')
+            .where('gm.winner.uid = :uid', { uid }).getRawMany();
         const loseGames = await this.gameRepository.createQueryBuilder('gm')
-        .where('gm.loser.uid = :uid', {uid}).getRawMany();
-        return {winGames, loseGames};
+            .where('gm.loser.uid = :uid', { uid }).getRawMany();
+        return { winGames, loseGames };
     }
 }

--- a/frontend/front/src/pages/ChatWrapper.tsx
+++ b/frontend/front/src/pages/ChatWrapper.tsx
@@ -8,22 +8,21 @@ import {
 } from "../components/atom/ModalAtom";
 
 import {
-	isGameStartedAtom,
-	isLoadingAtom,
-	isGameQuitAtom,
-	gameInviteInfoAtom,
 	gameinviteFromAtom,
+	isGameQuitAtom,
+	isGameStartedAtom,
+	isLoadingAtom
 } from "../components/atom/GameAtom";
 
 import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import * as chatAtom from "../components/atom/ChatAtom";
 import { refreshTokenAtom } from "../components/atom/LoginAtom";
 import { TFAAtom, UserAtom } from "../components/atom/UserAtom";
-import { useNavigate } from "react-router-dom";
 import { GetMyInfo, LogOut, RefreshToken } from "../event/api.request";
+import { AdminLogPrinter, PressKey } from "../event/event.util";
 import type * as chatType from "../socket/chat.dto";
 import * as socket from "../socket/chat.socket";
-import * as chatAtom from "../components/atom/ChatAtom";
-import { AdminLogPrinter, PressKey } from "../event/event.util";
 
 export default function ChatWrapper({ children }: { children: JSX.Element }) {
 	const setUserInfoModal = useSetAtom(userInfoModalAtom);
@@ -63,9 +62,7 @@ export default function ChatWrapper({ children }: { children: JSX.Element }) {
 	const quitRoomRelativeModal = () => {
 		setUserInfoModal(false);
 		setInviteModal(false);
-		// setRoomModal(false);
-	}	// setPwInputModal(false);
-
+	}
 
 	async function getMyinfoHandler() {
 		const getMeResponse = await GetMyInfo(adminConsole, setUserInfo, setTfa, true);
@@ -159,7 +156,7 @@ export default function ChatWrapper({ children }: { children: JSX.Element }) {
 	}, []);
 
 	useEffect(() => {
-		socket.socket.on("dm-list", (resDmUserList, mergeDmList) => {
+		socket.socket.on("dm-list", (resDmUserList, allDmList) => {
 			const tempDmRoomList: chatType.roomListDto = {};
 
 			setDmHistoryList({ ...resDmUserList });
@@ -187,7 +184,7 @@ export default function ChatWrapper({ children }: { children: JSX.Element }) {
 				};
 			});
 
-			Object.entries(mergeDmList).forEach((atom: any[]) => {
+			Object.entries(allDmList).forEach((atom: any[]) => {
 				if (Number(atom[1].senderId!) === userInfo.uid) { // from me
 					const tempMessageList: chatType.roomMessageDto[] = tempDmRoomList[Number(atom[1]?.receiverId!)].detail?.messageList!;
 					tempMessageList?.unshift({


### PR DESCRIPTION
* dm sender, receiver 따로 호출 후,  `합치고 정렬`하는 로직에서 where or where 로 한번에 가져와 유저에게 그냥 넘겨주는 방식으로 변경
* 상기한 기능을 위해 db service 하나 추가 (query builder)